### PR TITLE
rename test workflow to pull-request and add new master workflow

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,0 +1,39 @@
+name: master
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  master:
+    name: master
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.17
+        id: go
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+      - name: Test
+        run: |
+          make test
+      - name: Build
+        run: |
+          make immuproof
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Docker Build and Push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/codenotary/immuproof:master

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,14 +1,13 @@
-name: Test
+name: pull-request
 
 on:
-  push:
+  pull_request:
     branches:
       - master
-  pull_request:
 
 jobs:
-  cd:
-    name: Test
+  pull-request:
+    name: pull-request
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.x
@@ -19,8 +18,11 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
       - name: Test
-        run: make test
+        run: |
+          make test
       - name: Build
-        run: make immuproof
+        run: |
+          make immuproof
       - name: Docker build
-        run: make docker
+        run:
+          make docker


### PR DESCRIPTION
Changes:
- add `master` workflow which will execute go test, go build, and then docker build and push with `latest` tag for immuproof image
- the original `ci` workflow has been renamed to `pull-request` and executes on any PR opened against `master` branch