### PR TITLE
for docker image, reuse same binary built for the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
+          file: Dockerfile.release
           platforms: linux/amd64
           push: true
           tags: |

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,9 @@
+FROM debian:bullseye-slim
+LABEL org.opencontainers.image.authors="CodeNotary, Inc. <info@codenotary.com>"
+
+# Note: this requires running `make immuproof-release` before building the image
+COPY immuproof /usr/sbin/immuproof
+
+EXPOSE 8091
+
+ENTRYPOINT ["/usr/sbin/immuproof", "serve"]


### PR DESCRIPTION
Changes:
- for docker image, reuse same binary built for the release
This would allow us to have same binary inside the docker image with that tag version, as we have on the release page.